### PR TITLE
fixed broken parse of born effective charges

### DIFF
--- a/intensities.sh
+++ b/intensities.sh
@@ -6,7 +6,7 @@
 printf "..reading OUTCAR"
 BORN_NROWS=`grep NIONS OUTCAR | awk '{print $12*4+1}'`
 if [ `grep 'BORN' OUTCAR | wc -l` = 0 ] ; then printf " .. FAILED! Born effective charges missing! Bye! \n\n" ; exit 1 ; fi
-grep "in e, cummulative" -A $BORN_NROWS OUTCAR > born.txt
+grep "in |e|, cummulative" -A $BORN_NROWS OUTCAR > born.txt
 
 # extract Eigenvectors and eigenvalues
 if [ `grep 'SQRT(mass)' OUTCAR | wc -l` != 1 ] ; then printf " .. FAILED! Restart VASP with NWRITE=3! Bye! \n\n" ; exit 1 ; fi


### PR DESCRIPTION
VASP seems to have changed its output. 
The outfile now reads "... in|e|", instead of "in e", so I fixed the search string.